### PR TITLE
Bump `Process-PSModule` to v5

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,6 +27,6 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@001-unified-workflow
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v5
     secrets:
       APIKey: ${{ secrets.APIKey }}


### PR DESCRIPTION
This pull request updates the workflow reference in the `.github/workflows/Process-PSModule.yml` file to use a newer version of the shared workflow.

- Updated the `Process-PSModule` job to use the `v5` version of the shared workflow instead of the previous `001-unified-workflow` reference.