### PR TITLE
E2E: Import-TestData plumbing, section docs, and versioning

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,6 +27,11 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@60bdf8a5a4c92c53fcf2a8d23f7d5f5c93e6864e # v5.4.3
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@feat/import-testdata # E2E: temporary branch ref for the Import-TestData test
     secrets:
       APIKey: ${{ secrets.APIKey }}
+      # E2E: push a secret (masked in logs) and a variable (not masked) into the module test jobs.
+      # Import-TestData exposes each entry as $env:<name>; asserted in tests/Environment.Tests.ps1.
+      TestData: >-
+        { "secrets": { "TEST_SECRET": "${{ secrets.TEST_SECRET }}" },
+        "variables": { "TEST_VARIABLE": ${{ toJSON(vars.TEST_VARIABLE) }} } }

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v6.1.2
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@d4020f3c9c3621cebae5d8bf4ffaf10f55c1784a # v6.1.2
     secrets:
       APIKey: ${{ secrets.APIKey }}
       # E2E: push a secret (masked in logs) and a variable (not masked) into the module test jobs.

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@feat/import-testdata # E2E: temporary branch ref for the Import-TestData test
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v6.1.2
     secrets:
       APIKey: ${{ secrets.APIKey }}
       # E2E: push a secret (masked in logs) and a variable (not masked) into the module test jobs.

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -30,8 +30,12 @@ jobs:
     uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@d4020f3c9c3621cebae5d8bf4ffaf10f55c1784a # v6.1.2
     secrets:
       APIKey: ${{ secrets.APIKey }}
-      # E2E: push a secret (masked in logs) and a variable (not masked) into the module test jobs.
-      # Import-TestData exposes each entry as $env:<name>; asserted in tests/Environment.Tests.ps1.
       TestData: >-
-        { "secrets": { "TEST_SECRET": "${{ secrets.TEST_SECRET }}" },
-        "variables": { "TEST_VARIABLE": ${{ toJSON(vars.TEST_VARIABLE) }} } }
+        {
+          "secrets": {
+            "TEST_SECRET": "${{ secrets.TEST_SECRET }}"
+          },
+          "variables": {
+            "TEST_VARIABLE": "${{ vars.TEST_VARIABLE }}"
+          }
+        }

--- a/src/functions/public/DateAndTime/Get-CurrentDateTime.ps1
+++ b/src/functions/public/DateAndTime/Get-CurrentDateTime.ps1
@@ -23,7 +23,7 @@
         Returns the current date in a custom format like "Monday, January 20, 2026".
 
         .LINK
-        https://MariusStorhaug.github.io/MariusTestModule/Functions/Get-CurrentDateTime/
+        https://MariusStorhaug.github.io/MariusTestModule/Functions/DateAndTime/Get-CurrentDateTime/
     #>
     [OutputType([string])]
     [CmdletBinding()]

--- a/src/functions/public/DateAndTime/index.md
+++ b/src/functions/public/DateAndTime/index.md
@@ -1,0 +1,7 @@
+# Date and Time
+
+Functions for retrieving and formatting the current date and time.
+
+This section's landing page is provided by an `index.md` file. When Process-PSModule builds the
+documentation site, this page becomes the landing page for the **Date and Time** group in the
+navigation on GitHub Pages.

--- a/src/functions/public/Greetings/Get-Greeting.ps1
+++ b/src/functions/public/Greetings/Get-Greeting.ps1
@@ -23,7 +23,7 @@
         Returns "Good Morning, Alice!" to the user.
 
         .LINK
-        https://MariusStorhaug.github.io/MariusTestModule/Functions/Get-Greeting/
+        https://MariusStorhaug.github.io/MariusTestModule/Functions/Greetings/Get-Greeting/
     #>
     [OutputType([string])]
     [CmdletBinding()]

--- a/src/functions/public/Greetings/Greetings.md
+++ b/src/functions/public/Greetings/Greetings.md
@@ -1,0 +1,7 @@
+# Greetings
+
+Functions for composing greeting messages.
+
+This section's landing page is provided by a file named after its folder (`Greetings.md`). When
+Process-PSModule builds the documentation site, this page becomes the landing page for the
+**Greetings** group in the navigation on GitHub Pages.

--- a/tests/Environment.Tests.ps1
+++ b/tests/Environment.Tests.ps1
@@ -14,12 +14,6 @@
 param()
 
 Describe 'TestData is pushed into the module tests' {
-    # TEST_SECRET (from the "secrets" map, masked) and TEST_VARIABLE (from the "variables" map, not
-    # masked) are public non-secret fixtures that exist only to prove the calling workflow can push
-    # secrets and variables into the module test jobs. The calling workflow passes them through a
-    # single TestData object and Import-TestData (from Install-PSModuleHelpers) exposes them as
-    # environment variables; these tests confirm they arrive with the expected values.
-
     It 'Exposes the secret from the "secrets" map' {
         $actual = [System.Environment]::GetEnvironmentVariable('TEST_SECRET')
         $actual | Should -Not -BeNullOrEmpty
@@ -33,9 +27,6 @@ Describe 'TestData is pushed into the module tests' {
     }
 
     It 'Masks the secret in the log even when a test prints it in plain text' {
-        # Deliberately try to leak both values to the log with Write-Host. Because Import-TestData
-        # registered the secret via ::add-mask::, GitHub Actions redacts it to *** in the log, while
-        # the variable (not masked) is printed verbatim. Inspect the job log to see the difference.
         Write-Host "Secret in plain text:   $env:TEST_SECRET"
         Write-Host "Variable in plain text: $env:TEST_VARIABLE"
     }

--- a/tests/Environment.Tests.ps1
+++ b/tests/Environment.Tests.ps1
@@ -1,0 +1,30 @@
+﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Required for Pester tests'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', '',
+    Justification = 'Required for Pester tests'
+)]
+[CmdletBinding()]
+param()
+
+Describe 'TestData is pushed into the module tests' {
+    # TEST_SECRET (from the "secrets" map, masked) and TEST_VARIABLE (from the "variables" map, not
+    # masked) are public non-secret fixtures that exist only to prove the calling workflow can push
+    # secrets and variables into the module test jobs. The calling workflow passes them through a
+    # single TestData object and Import-TestData (from Install-PSModuleHelpers) exposes them as
+    # environment variables; these tests confirm they arrive with the expected values.
+
+    It 'Exposes the secret from the "secrets" map' {
+        $actual = [System.Environment]::GetEnvironmentVariable('TEST_SECRET')
+        $actual | Should -Not -BeNullOrEmpty
+        $actual | Should -BeExactly 'mariustestmodule-secret-fixture-value'
+    }
+
+    It 'Exposes the variable from the "variables" map' {
+        $actual = [System.Environment]::GetEnvironmentVariable('TEST_VARIABLE')
+        $actual | Should -Not -BeNullOrEmpty
+        $actual | Should -BeExactly 'mariustestmodule-variable-fixture-value'
+    }
+}

--- a/tests/Environment.Tests.ps1
+++ b/tests/Environment.Tests.ps1
@@ -6,6 +6,10 @@
     'PSUseDeclaredVarsMoreThanAssignments', '',
     Justification = 'Required for Pester tests'
 )]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingWriteHost', '',
+    Justification = 'Deliberately prints the values to the log to demonstrate GitHub Actions masking'
+)]
 [CmdletBinding()]
 param()
 
@@ -26,5 +30,13 @@ Describe 'TestData is pushed into the module tests' {
         $actual = [System.Environment]::GetEnvironmentVariable('TEST_VARIABLE')
         $actual | Should -Not -BeNullOrEmpty
         $actual | Should -BeExactly 'mariustestmodule-variable-fixture-value'
+    }
+
+    It 'Masks the secret in the log even when a test prints it in plain text' {
+        # Deliberately try to leak both values to the log with Write-Host. Because Import-TestData
+        # registered the secret via ::add-mask::, GitHub Actions redacts it to *** in the log, while
+        # the variable (not masked) is printed verbatim. Inspect the job log to see the difference.
+        Write-Host "Secret in plain text:   $env:TEST_SECRET"
+        Write-Host "Variable in plain text: $env:TEST_VARIABLE"
     }
 }


### PR DESCRIPTION
End-to-end test of the TestData plumbing fix, exercised through this module **without merging** the
underlying changes.

## Wiring

- CI calls `PSModule/Process-PSModule/.github/workflows/workflow.yml@feat/import-testdata`
  (PR PSModule/Process-PSModule#377), which installs
  `PSModule/Install-PSModuleHelpers@feat/import-testdata` (PR PSModule/Install-PSModuleHelpers#20)
  and runs its new `Import-TestData` command.

## What to observe

- **Secrets + variables pushed into the tests** — the calling workflow passes a `TestData` object with
  a `secrets` map (`TEST_SECRET`, masked in logs) and a `variables` map (`TEST_VARIABLE`, not masked).
  `tests/Environment.Tests.ps1` asserts both arrive with their exact fixture values inside the module
  test job.
- **(A) Versioning** — this PR is labelled `Minor`; the pipeline computes the next version accordingly.
- **(B) Documentation hierarchy** — public functions are grouped into sections with landing pages on
  the section nodes:
  - `Greetings/` (landing page from `Greetings.md`) → `Get-Greeting`
  - `DateAndTime/` (landing page from `index.md`) → `Get-CurrentDateTime`
  - `Get-PSModuleTest` stays at the top level

> Throwaway E2E harness — not intended to merge.
