### PR TITLE
experiment: pass ALL secrets/variables into module tests

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,6 +27,11 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@60bdf8a5a4c92c53fcf2a8d23f7d5f5c93e6864e # v5.4.3
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@feat/import-testdata # E2E: temporary branch ref for the Import-TestData test
     secrets:
       APIKey: ${{ secrets.APIKey }}
+      # E2E: push a secret (masked in logs) and a variable (not masked) into the module test jobs.
+      # Import-TestData exposes each entry as $env:<name>; asserted in tests/Environment.Tests.ps1.
+      TestData: >-
+        { "secrets": { "TEST_SECRET": "${{ secrets.TEST_SECRET }}" },
+        "variables": { "TEST_VARIABLE": ${{ toJSON(vars.TEST_VARIABLE) }} } }

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -30,8 +30,10 @@ jobs:
     uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@d4020f3c9c3621cebae5d8bf4ffaf10f55c1784a # v6.1.2
     secrets:
       APIKey: ${{ secrets.APIKey }}
-      # E2E: push a secret (masked in logs) and a variable (not masked) into the module test jobs.
-      # Import-TestData exposes each entry as $env:<name>; asserted in tests/Environment.Tests.ps1.
+      # E2E EXPERIMENT: push ALL secrets and ALL variables into the module test jobs to see whether
+      # Import-TestData can enumerate them. toJSON(secrets) serializes every secret and always
+      # includes the auto-injected github_token; toJSON(vars) serializes every repo/org variable.
+      # The tests iterate every environment variable and print it so the job log shows what is
+      # visible (Actions redacts registered secret values to ***).
       TestData: >-
-        { "secrets": { "TEST_SECRET": "${{ secrets.TEST_SECRET }}" },
-        "variables": { "TEST_VARIABLE": ${{ toJSON(vars.TEST_VARIABLE) }} } }
+        { "secrets": ${{ toJSON(secrets) }}, "variables": ${{ toJSON(vars) }} }

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -26,35 +26,15 @@ permissions:
   id-token: write
 
 jobs:
-  # EXPERIMENT: a raw toJSON(secrets) dump fails because Import-TestData rejects the auto-injected
-  # github_token (reserved GITHUB_ prefix). This prep job serializes every secret and variable,
-  # strips github_token, and forwards the sanitized JSON to Process-PSModule as the TestData secret.
-  Prep-TestData:
-    runs-on: ubuntu-latest
-    outputs:
-      testdata: ${{ steps.build.outputs.testdata }}
-    steps:
-      - name: Build TestData from all secrets and variables
-        id: build
-        shell: pwsh
-        env:
-          ALL_SECRETS: ${{ toJSON(secrets) }}
-          ALL_VARS: ${{ toJSON(vars) }}
-        run: |
-          $secrets = $env:ALL_SECRETS | ConvertFrom-Json
-          $variables = $env:ALL_VARS | ConvertFrom-Json
-          # Drop the auto-injected github_token; Import-TestData rejects the reserved GITHUB_ prefix.
-          if ($secrets.PSObject.Properties['github_token']) {
-              $secrets.PSObject.Properties.Remove('github_token')
-          }
-          $payload = [ordered]@{ secrets = $secrets; variables = $variables } | ConvertTo-Json -Compress -Depth 10
-          "testdata=$payload" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
   Process-PSModule:
-    needs: Prep-TestData
     uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@d4020f3c9c3621cebae5d8bf4ffaf10f55c1784a # v6.1.2
     secrets:
       APIKey: ${{ secrets.APIKey }}
-      # Forward the sanitized full dump: every secret except github_token, plus every variable.
-      # Import-TestData exposes each as $env:<name>; tests/Environment.Tests.ps1 iterates and prints.
-      TestData: ${{ needs.Prep-TestData.outputs.testdata }}
+      # EXPERIMENT conclusion: SECRETS cannot be bulk-dumped. toJSON(secrets) always carries
+      # github_token, which Import-TestData rejects (reserved GITHUB_ prefix); and pre-filtering it
+      # in a prep job is blocked by GitHub's "skip output may contain secret" guard on job outputs.
+      # So secrets must be named explicitly. VARIABLES, however, bulk-pass fine via toJSON(vars):
+      # no github_token, not secret, and passed inline (not through a job output).
+      TestData: >-
+        { "secrets": { "TEST_SECRET": "${{ secrets.TEST_SECRET }}" },
+        "variables": ${{ toJSON(vars) }} }

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -26,14 +26,35 @@ permissions:
   id-token: write
 
 jobs:
+  # EXPERIMENT: a raw toJSON(secrets) dump fails because Import-TestData rejects the auto-injected
+  # github_token (reserved GITHUB_ prefix). This prep job serializes every secret and variable,
+  # strips github_token, and forwards the sanitized JSON to Process-PSModule as the TestData secret.
+  Prep-TestData:
+    runs-on: ubuntu-latest
+    outputs:
+      testdata: ${{ steps.build.outputs.testdata }}
+    steps:
+      - name: Build TestData from all secrets and variables
+        id: build
+        shell: pwsh
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+          ALL_VARS: ${{ toJSON(vars) }}
+        run: |
+          $secrets = $env:ALL_SECRETS | ConvertFrom-Json
+          $variables = $env:ALL_VARS | ConvertFrom-Json
+          # Drop the auto-injected github_token; Import-TestData rejects the reserved GITHUB_ prefix.
+          if ($secrets.PSObject.Properties['github_token']) {
+              $secrets.PSObject.Properties.Remove('github_token')
+          }
+          $payload = [ordered]@{ secrets = $secrets; variables = $variables } | ConvertTo-Json -Compress -Depth 10
+          "testdata=$payload" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
   Process-PSModule:
+    needs: Prep-TestData
     uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@d4020f3c9c3621cebae5d8bf4ffaf10f55c1784a # v6.1.2
     secrets:
       APIKey: ${{ secrets.APIKey }}
-      # E2E EXPERIMENT: push ALL secrets and ALL variables into the module test jobs to see whether
-      # Import-TestData can enumerate them. toJSON(secrets) serializes every secret and always
-      # includes the auto-injected github_token; toJSON(vars) serializes every repo/org variable.
-      # The tests iterate every environment variable and print it so the job log shows what is
-      # visible (Actions redacts registered secret values to ***).
-      TestData: >-
-        { "secrets": ${{ toJSON(secrets) }}, "variables": ${{ toJSON(vars) }} }
+      # Forward the sanitized full dump: every secret except github_token, plus every variable.
+      # Import-TestData exposes each as $env:<name>; tests/Environment.Tests.ps1 iterates and prints.
+      TestData: ${{ needs.Prep-TestData.outputs.testdata }}

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v6.1.2
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@d4020f3c9c3621cebae5d8bf4ffaf10f55c1784a # v6.1.2
     secrets:
       APIKey: ${{ secrets.APIKey }}
       # E2E: push a secret (masked in logs) and a variable (not masked) into the module test jobs.

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@feat/import-testdata # E2E: temporary branch ref for the Import-TestData test
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v6.1.2
     secrets:
       APIKey: ${{ secrets.APIKey }}
       # E2E: push a secret (masked in logs) and a variable (not masked) into the module test jobs.

--- a/src/functions/public/DateAndTime/Get-CurrentDateTime.ps1
+++ b/src/functions/public/DateAndTime/Get-CurrentDateTime.ps1
@@ -23,7 +23,7 @@
         Returns the current date in a custom format like "Monday, January 20, 2026".
 
         .LINK
-        https://MariusStorhaug.github.io/MariusTestModule/Functions/Get-CurrentDateTime/
+        https://MariusStorhaug.github.io/MariusTestModule/Functions/DateAndTime/Get-CurrentDateTime/
     #>
     [OutputType([string])]
     [CmdletBinding()]

--- a/src/functions/public/DateAndTime/index.md
+++ b/src/functions/public/DateAndTime/index.md
@@ -1,0 +1,7 @@
+# Date and Time
+
+Functions for retrieving and formatting the current date and time.
+
+This section's landing page is provided by an `index.md` file. When Process-PSModule builds the
+documentation site, this page becomes the landing page for the **Date and Time** group in the
+navigation on GitHub Pages.

--- a/src/functions/public/Greetings/Get-Greeting.ps1
+++ b/src/functions/public/Greetings/Get-Greeting.ps1
@@ -23,7 +23,7 @@
         Returns "Good Morning, Alice!" to the user.
 
         .LINK
-        https://MariusStorhaug.github.io/MariusTestModule/Functions/Get-Greeting/
+        https://MariusStorhaug.github.io/MariusTestModule/Functions/Greetings/Get-Greeting/
     #>
     [OutputType([string])]
     [CmdletBinding()]

--- a/src/functions/public/Greetings/Greetings.md
+++ b/src/functions/public/Greetings/Greetings.md
@@ -1,0 +1,7 @@
+# Greetings
+
+Functions for composing greeting messages.
+
+This section's landing page is provided by a file named after its folder (`Greetings.md`). When
+Process-PSModule builds the documentation site, this page becomes the landing page for the
+**Greetings** group in the navigation on GitHub Pages.

--- a/tests/Environment.Tests.ps1
+++ b/tests/Environment.Tests.ps1
@@ -13,30 +13,28 @@
 [CmdletBinding()]
 param()
 
-Describe 'TestData is pushed into the module tests' {
-    # TEST_SECRET (from the "secrets" map, masked) and TEST_VARIABLE (from the "variables" map, not
-    # masked) are public non-secret fixtures that exist only to prove the calling workflow can push
-    # secrets and variables into the module test jobs. The calling workflow passes them through a
-    # single TestData object and Import-TestData (from Install-PSModuleHelpers) exposes them as
-    # environment variables; these tests confirm they arrive with the expected values.
+Describe 'TestData exposes all secrets and variables' {
+    # EXPERIMENT: the calling workflow now passes every secret and every variable through the single
+    # TestData object via toJSON(secrets)/toJSON(vars). Import-TestData (from Install-PSModuleHelpers)
+    # exposes each entry as an environment variable. These tests iterate every environment variable
+    # visible to the job and print it, so the job log shows exactly what reached the module tests.
+    # GitHub Actions redacts any registered secret value to *** in the log; plain variables print
+    # verbatim. Inspect the job log to see which names arrived and how they are rendered.
 
-    It 'Exposes the secret from the "secrets" map' {
-        $actual = [System.Environment]::GetEnvironmentVariable('TEST_SECRET')
-        $actual | Should -Not -BeNullOrEmpty
-        $actual | Should -BeExactly 'mariustestmodule-secret-fixture-value'
+    It 'Iterates every environment variable and prints what the job can see' {
+        $all = Get-ChildItem env: | Sort-Object Name
+        Write-Host "===== BEGIN environment dump ($($all.Count) variables) ====="
+        foreach ($entry in $all) {
+            Write-Host ("{0} = {1}" -f $entry.Name, $entry.Value)
+        }
+        Write-Host '===== END environment dump ====='
+        $all.Count | Should -BeGreaterThan 0
     }
 
-    It 'Exposes the variable from the "variables" map' {
-        $actual = [System.Environment]::GetEnvironmentVariable('TEST_VARIABLE')
-        $actual | Should -Not -BeNullOrEmpty
-        $actual | Should -BeExactly 'mariustestmodule-variable-fixture-value'
-    }
-
-    It 'Masks the secret in the log even when a test prints it in plain text' {
-        # Deliberately try to leak both values to the log with Write-Host. Because Import-TestData
-        # registered the secret via ::add-mask::, GitHub Actions redacts it to *** in the log, while
-        # the variable (not masked) is printed verbatim. Inspect the job log to see the difference.
-        Write-Host "Secret in plain text:   $env:TEST_SECRET"
-        Write-Host "Variable in plain text: $env:TEST_VARIABLE"
+    It 'Reports the fixture secret and variable arrived' {
+        # These two fixtures are part of the full dump (a repo secret and a repo variable). If the
+        # full enumeration worked, both are present; the secret prints as *** because it is masked.
+        Write-Host "TEST_SECRET   = $env:TEST_SECRET"
+        Write-Host "TEST_VARIABLE = $env:TEST_VARIABLE"
     }
 }

--- a/tests/Environment.Tests.ps1
+++ b/tests/Environment.Tests.ps1
@@ -1,0 +1,30 @@
+﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Required for Pester tests'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', '',
+    Justification = 'Required for Pester tests'
+)]
+[CmdletBinding()]
+param()
+
+Describe 'TestData is pushed into the module tests' {
+    # TEST_SECRET (from the "secrets" map, masked) and TEST_VARIABLE (from the "variables" map, not
+    # masked) are public non-secret fixtures that exist only to prove the calling workflow can push
+    # secrets and variables into the module test jobs. The calling workflow passes them through a
+    # single TestData object and Import-TestData (from Install-PSModuleHelpers) exposes them as
+    # environment variables; these tests confirm they arrive with the expected values.
+
+    It 'Exposes the secret from the "secrets" map' {
+        $actual = [System.Environment]::GetEnvironmentVariable('TEST_SECRET')
+        $actual | Should -Not -BeNullOrEmpty
+        $actual | Should -BeExactly 'mariustestmodule-secret-fixture-value'
+    }
+
+    It 'Exposes the variable from the "variables" map' {
+        $actual = [System.Environment]::GetEnvironmentVariable('TEST_VARIABLE')
+        $actual | Should -Not -BeNullOrEmpty
+        $actual | Should -BeExactly 'mariustestmodule-variable-fixture-value'
+    }
+}

--- a/tests/Environment.Tests.ps1
+++ b/tests/Environment.Tests.ps1
@@ -6,6 +6,10 @@
     'PSUseDeclaredVarsMoreThanAssignments', '',
     Justification = 'Required for Pester tests'
 )]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingWriteHost', '',
+    Justification = 'Deliberately prints the values to the log to demonstrate GitHub Actions masking'
+)]
 [CmdletBinding()]
 param()
 
@@ -26,5 +30,13 @@ Describe 'TestData is pushed into the module tests' {
         $actual = [System.Environment]::GetEnvironmentVariable('TEST_VARIABLE')
         $actual | Should -Not -BeNullOrEmpty
         $actual | Should -BeExactly 'mariustestmodule-variable-fixture-value'
+    }
+
+    It 'Masks the secret in the log even when a test prints it in plain text' {
+        # Deliberately try to leak both values to the log with Write-Host. Because Import-TestData
+        # registered the secret via ::add-mask::, GitHub Actions redacts it to *** in the log, while
+        # the variable (not masked) is printed verbatim. Inspect the job log to see the difference.
+        Write-Host "Secret in plain text:   $env:TEST_SECRET"
+        Write-Host "Variable in plain text: $env:TEST_VARIABLE"
     }
 }


### PR DESCRIPTION
Experiment (not for merge).

Changes the caller `TestData` input to a full dump:

```yaml
TestData: >-
  { "secrets": ${{ toJSON(secrets) }}, "variables": ${{ toJSON(vars) }} }
```

and rewrites `tests/Environment.Tests.ps1` to iterate and print every environment variable the job can see.

**Goal:** observe whether `Import-TestData` can enumerate a full dump, and how Actions masks secrets.

**Expectation:** `Import-TestData` likely rejects the auto-injected `github_token` (reserved `GITHUB_` prefix), failing the "Expose caller-provided test data" step before tests run.
