### PR TITLE
⚙️ [Maintenance]: Adopt Process-PSModule v6.1.4

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@d4020f3c9c3621cebae5d8bf4ffaf10f55c1784a # v6.1.2
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@da180bac16b13bfbcdf08b2e4e221b5b49e5ff28 # v6.1.4
     secrets:
       APIKey: ${{ secrets.APIKey }}
       TestData: >-


### PR DESCRIPTION
This repository's CI now runs on Process-PSModule v6.1.4. Scheduled and manual (`workflow_dispatch`) runs work again, and linting/testing run against the latest tooling. The reusable workflow's caller contract is unchanged, so no settings or secrets needed updating.

## Changed: CI now runs on Process-PSModule v6.1.4

- Scheduled (cron) and manual (`workflow_dispatch`) runs no longer fail at the `Plan` job — v6.1.4 resolves the current published version on non–pull-request events instead of throwing (Process-PSModule #375, fixes #373).
- Linting and testing run against the latest tooling — v6.1.3 brings PSScriptAnalyzer via Invoke-ScriptAnalyzer v5.0.0 and Invoke-Pester v5.1.0 via Test-PSModule v3.0.14.

## Technical Details

- `.github/workflows/Process-PSModule.yml`: pin bumped from `v6.1.2` (`d4020f3c9c3621cebae5d8bf4ffaf10f55c1784a`) to `v6.1.4` (`da180bac16b13bfbcdf08b2e4e221b5b49e5ff28`).
- No caller-facing input/secret changes across v6.1.3 and v6.1.4 — the `APIKEY`/`TestData` inputs and the `Settings` contract are preserved.
- v6.1.3 (Patch): Invoke-ScriptAnalyzer v4.1.3 → v5.0.0, Test-PSModule v3.0.13 → v3.0.14.
- v6.1.4 (Fix): Resolve-PSModuleVersion v1.1.4 → v1.1.5, fixing the non-PR `Plan` failure introduced in v6.1.0.
