### PR TITLE
test: pipeline via PSMA subfolder actions

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@da180bac16b13bfbcdf08b2e4e221b5b49e5ff28 # v6.1.4
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@test/use-psma-actions
     secrets:
       APIKey: ${{ secrets.APIKey }}
       TestData: >-

--- a/src/functions/public/Get-PSModuleTest.ps1
+++ b/src/functions/public/Get-PSModuleTest.ps1
@@ -24,3 +24,5 @@
     )
     Write-Output "Hello, $Name!"
 }
+
+# PSMA subfolder-action pipeline test (2026-07-12T21:48:17.0732000+02:00)


### PR DESCRIPTION
Validates the PSMA consolidation end-to-end: this points the caller at `PSModule/Process-PSModule/.github/workflows/workflow.yml@test/use-psma-actions`, whose sub-workflows call the framework actions from their **PSMA subfolder** locations (`PSModule/PSMA/<Action>@move-actions-into-folders`) instead of the standalone action repos.

The trivial `src/` change triggers the full pipeline (Plan → Build → Test → Docs → …) so every consolidated action runs.

Do not merge — test PR only.