### PR TITLE
⚙️ [Maintenance]: Repository automation now uses Process-PSModule v6.1.7

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@da180bac16b13bfbcdf08b2e4e221b5b49e5ff28 # v6.1.4
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@8b1a2617a0686ceaeadc6fa8e2f395edda93cc6d # v6.1.7
     secrets:
       APIKey: ${{ secrets.APIKey }}
       TestData: >-


### PR DESCRIPTION
Repository automation now uses Process-PSModule v6.1.7. This keeps the module workflow aligned with the latest shared Process-PSModule updates without changing the module's shipped behavior.

> ⚠️ This PR has no linked issue. Consider creating one for traceability.

## Changed: Repository automation uses Process-PSModule v6.1.7

The reusable Process-PSModule workflow reference is updated from v6.1.4 to v6.1.7. This affects build, test, and publish automation for the repository, but it does not change the module's public commands or runtime behavior.

## Technical Details

- Updated `.github/workflows/Process-PSModule.yml` to point at `PSModule/Process-PSModule/.github/workflows/workflow.yml@8b1a2617a0686ceaeadc6fa8e2f395edda93cc6d` (`v6.1.7`) instead of `v6.1.4`.
- Local validation: `Invoke-Pester -Path tests -Output Minimal` passed after reproducing the workflow test setup by seeding `TEST_SECRET` and `TEST_VARIABLE` and dot-sourcing functions from `src/functions/public`.
