### PR TITLE
Restore left nav and use Home page title

### DIFF
--- a/.github/zensical.toml
+++ b/.github/zensical.toml
@@ -2,9 +2,6 @@
 site_name = "-{{ REPO_NAME }}-"
 repo_name = "-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"
 repo_url = "https://github.com/-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"
-nav = [
-  {"Home" = "index.md"},
-]
 
 [project.theme]
 language = "en"

--- a/.github/zensical.toml
+++ b/.github/zensical.toml
@@ -5,24 +5,35 @@ repo_url = "https://github.com/-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"
 
 [project.theme]
 language = "en"
-font.text = "Roboto"
-font.code = "Sono"
+font.text = "Mona Sans"
+font.code = "Source Code Pro"
 logo = "Assets/icon.png"
 favicon = "Assets/icon.png"
 features = [
+  "announce.dismiss",
+  "content.action.edit",
+  "content.action.view",
+  "content.code.annotate",
   "content.code.copy",
+  "content.tooltips",
+  "navigation.footer",
+  "navigation.instant.prefetch",
+  "navigation.instant.preview",
   "navigation.instant",
   "navigation.instant.progress",
   "navigation.indexes",
+  "navigation.tabs",
   "navigation.top",
   "navigation.tracking",
-  "navigation.expand",
+  "search.share",
   "search.suggest",
   "search.highlight",
+  "toc.follow",
 ]
 
 [project.theme.icon]
 repo = "material/github"
+link = "material/link-variant"
 
 [[project.theme.palette]]
 media = "(prefers-color-scheme)"
@@ -33,15 +44,15 @@ toggle.name = "Switch to dark mode"
 media = "(prefers-color-scheme: dark)"
 scheme = "slate"
 primary = "black"
-accent = "green"
+accent = "light blue"
 toggle.icon = "material/toggle-switch-off-outline"
 toggle.name = "Switch to light mode"
 
 [[project.theme.palette]]
 media = "(prefers-color-scheme: light)"
 scheme = "default"
-primary = "indigo"
-accent = "green"
+primary = "black"
+accent = "light blue"
 toggle.icon = "material/toggle-switch"
 toggle.name = "Switch to system preference"
 

--- a/.github/zensical.toml
+++ b/.github/zensical.toml
@@ -2,6 +2,9 @@
 site_name = "-{{ REPO_NAME }}-"
 repo_name = "-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"
 repo_url = "https://github.com/-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"
+nav = [
+  {"Home" = "index.md"},
+]
 
 [project.theme]
 language = "en"
@@ -22,7 +25,6 @@ features = [
   "navigation.instant",
   "navigation.instant.progress",
   "navigation.indexes",
-  "navigation.tabs",
   "navigation.top",
   "navigation.tracking",
   "search.share",

--- a/README.md
+++ b/README.md
@@ -67,3 +67,5 @@ You can either help by picking up an existing issue or submit a new one if you h
 ## Acknowledgements
 
 Here is a list of people and projects that helped this project in some way.
+
+Validation marker: docs publish verification run at 2026-07-18 22:41:56Z.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# {{ NAME }}
+# Home
 
 {{ DESCRIPTION }}
 


### PR DESCRIPTION
## Summary
- remove explicit nav override so the full left navigation is auto-generated
- keep top tabs disabled by not enabling 
avigation.tabs`n- rename the first page heading in README to Home
