### PR TITLE
Hide top tabs and keep left menu

### DIFF
--- a/.github/zensical.toml
+++ b/.github/zensical.toml
@@ -2,9 +2,6 @@
 site_name = "-{{ REPO_NAME }}-"
 repo_name = "-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"
 repo_url = "https://github.com/-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"
-nav = [
-  {"Home" = "index.md"},
-]
 
 [project.theme]
 language = "en"

--- a/.github/zensical.toml
+++ b/.github/zensical.toml
@@ -2,6 +2,7 @@
 site_name = "-{{ REPO_NAME }}-"
 repo_name = "-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"
 repo_url = "https://github.com/-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"
+extra_css = ["data:text/css,.md-tabs%7Bdisplay%3Anone%20!important%3B%7D"]
 
 [project.theme]
 language = "en"

--- a/.github/zensical.toml
+++ b/.github/zensical.toml
@@ -25,7 +25,6 @@ features = [
   "navigation.instant",
   "navigation.instant.progress",
   "navigation.indexes",
-  "navigation.tabs",
   "navigation.top",
   "navigation.tracking",
   "search.share",


### PR DESCRIPTION
## Summary
- add a Zensical xtra_css override to hide the top md-tabs bar
- keep the existing left menu behavior unchanged
