### PR TITLE
Hide top tabs while keeping left menu

### DIFF
--- a/.github/zensical.toml
+++ b/.github/zensical.toml
@@ -2,7 +2,6 @@
 site_name = "-{{ REPO_NAME }}-"
 repo_name = "-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"
 repo_url = "https://github.com/-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"
-extra_css = ["data:text/css,.md-tabs%7Bdisplay%3Anone%20!important%3B%7D"]
 
 [project.theme]
 language = "en"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Home
 
+<style>
+  .md-tabs {
+    display: none !important;
+  }
+</style>
+
 {{ DESCRIPTION }}
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
- remove ineffective config-level data URI css override
- add a page-level style in README to hide the top md-tabs bar
- keep left menu behavior unchanged
