### PR TITLE
Expand first-level left menu by default

### DIFF
--- a/.github/zensical.toml
+++ b/.github/zensical.toml
@@ -2,7 +2,6 @@
 site_name = "-{{ REPO_NAME }}-"
 repo_name = "-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"
 repo_url = "https://github.com/-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"
-extra_css = ["data:text/css,.md-tabs%7Bdisplay%3Anone%20!important%3B%7D"]
 
 [project.theme]
 language = "en"

--- a/.github/zensical.toml
+++ b/.github/zensical.toml
@@ -22,6 +22,7 @@ features = [
   "navigation.instant",
   "navigation.instant.progress",
   "navigation.indexes",
+  "navigation.expand",
   "navigation.top",
   "navigation.tracking",
   "search.share",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Home
 
+<style>
+  .md-tabs {
+    display: none !important;
+  }
+</style>
+
 {{ DESCRIPTION }}
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
- enable 
avigation.expand in Zensical theme features
- keep current no-top-tabs behavior and left-menu layout
