### PR TITLE
Persist left-menu fold state with first-level defaults

### DIFF
--- a/.github/docs/nav-state.js
+++ b/.github/docs/nav-state.js
@@ -1,0 +1,86 @@
+(() => {
+  const storageKey = "zensical-nav-state-v1";
+  let lastSignature = "";
+
+  const getToggles = () =>
+    Array.from(document.querySelectorAll("input.md-nav__toggle.md-toggle[id]"));
+
+  const getPrimaryList = () =>
+    document.querySelector("nav.md-nav--primary > ul.md-nav__list");
+
+  const applyDefaultTopLevelState = (toggles) => {
+    const primaryList = getPrimaryList();
+    if (!primaryList) {
+      return;
+    }
+
+    const topLevelToggles = Array.from(
+      primaryList.querySelectorAll(
+        ":scope > li > input.md-nav__toggle.md-toggle[id]"
+      )
+    );
+    const topLevelIds = new Set(topLevelToggles.map((toggle) => toggle.id));
+
+    for (const toggle of toggles) {
+      toggle.checked = topLevelIds.has(toggle.id);
+    }
+  };
+
+  const restoreState = (toggles) => {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) {
+      applyDefaultTopLevelState(toggles);
+      return;
+    }
+
+    try {
+      const state = JSON.parse(raw);
+      for (const toggle of toggles) {
+        if (Object.prototype.hasOwnProperty.call(state, toggle.id)) {
+          toggle.checked = !!state[toggle.id];
+        }
+      }
+    } catch {
+      applyDefaultTopLevelState(toggles);
+    }
+  };
+
+  const persistState = (toggles) => {
+    const state = {};
+    for (const toggle of toggles) {
+      state[toggle.id] = !!toggle.checked;
+    }
+    localStorage.setItem(storageKey, JSON.stringify(state));
+  };
+
+  const initialize = () => {
+    const toggles = getToggles();
+    if (toggles.length === 0) {
+      return;
+    }
+
+    const signature = toggles.map((toggle) => toggle.id).join("|");
+    if (signature === lastSignature) {
+      return;
+    }
+
+    lastSignature = signature;
+    restoreState(toggles);
+    for (const toggle of toggles) {
+      if (toggle.dataset.navStateBound === "true") {
+        continue;
+      }
+
+      toggle.dataset.navStateBound = "true";
+      toggle.addEventListener("change", () => persistState(getToggles()));
+    }
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initialize, { once: true });
+  } else {
+    initialize();
+  }
+
+  setInterval(initialize, 500);
+})();

--- a/.github/zensical.toml
+++ b/.github/zensical.toml
@@ -2,6 +2,7 @@
 site_name = "-{{ REPO_NAME }}-"
 repo_name = "-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"
 repo_url = "https://github.com/-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"
+extra_javascript = ["https://cdn.jsdelivr.net/gh/-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-@main/.github/docs/nav-state.js"]
 
 [project.theme]
 language = "en"
@@ -22,7 +23,6 @@ features = [
   "navigation.instant",
   "navigation.instant.progress",
   "navigation.indexes",
-  "navigation.expand",
   "navigation.top",
   "navigation.tracking",
   "search.share",


### PR DESCRIPTION
## Summary
- remove 
avigation.expand so the menu is not force-expanded globally
- add a global nav-state script in .github/docs/nav-state.js`n- load the script through xtra_javascript with repo placeholders so each repo resolves its own main-branch asset

## Behavior
- first-level groups expand by default when no saved state exists
- user fold/unfold choices persist in localStorage across navigation
