### PR TITLE
Refresh docs publish with centralized nav state

### DIFF
--- a/.github/zensical.toml
+++ b/.github/zensical.toml
@@ -1,4 +1,5 @@
 # Navigation behavior is injected centrally by Process-PSModule Build-Site.
+# This file remains repo-local for theme and docs metadata only.
 [project]
 site_name = "-{{ REPO_NAME }}-"
 repo_name = "-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
     display: none !important;
   }
 </style>
+<!-- Docs publish refresh marker -->
 
 {{ DESCRIPTION }}
 


### PR DESCRIPTION
## Summary
- add a hidden README marker to trigger full docs publish path
- publish the currently merged centralized nav-state framework behavior
