### PR TITLE
Align Process-PSModule triggers with merge commits

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -4,11 +4,13 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
     types:
-      - closed
       - opened
       - reopened
       - synchronize


### PR DESCRIPTION
## Summary
- add a push trigger for main in Process-PSModule
- remove pull_request.closed from the trigger list
- keep PR validation triggers (opened, eopened, synchronize, labeled) unchanged

## Why
This aligns post-merge automation with actual merge commits on main and avoids a separate run path that fires only on PR close events.