### PR TITLE
Restore merged-PR context for site publishing

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -4,13 +4,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
     types:
+      - closed
       - opened
       - reopened
       - synchronize

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -4,11 +4,13 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
     types:
-      - closed
       - opened
       - reopened
       - synchronize

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ To find examples of each of the commands you can use Get-Help -Examples 'Command
 
 ## Documentation
 
-Link to further documentation if available, or describe where in the repository users can find more detailed documentation about
-the module's functions and features.
+Function documentation is published to the project site under the `Functions` section and is generated from the module source.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Import-Module -Name {{ NAME }}
 
 ## Usage
 
-Here is a list of example that are typical use cases for the module.
+Here is a list of examples that are typical use cases for the module.
 
 ### Example 1: Greet an entity
 
@@ -41,7 +41,7 @@ Hello, World!
 Provide examples for typical commands that a user would like to do with the module.
 
 ```powershell
-Import-Module -Name PSModuleTemplate
+Import-Module -Name MariusTestModule
 ```
 
 ### Find more examples


### PR DESCRIPTION
## Summary
- remove push trigger on main
- restore pull_request.closed in Process-PSModule triggers

## Why
Publish-Site in Process-PSModule is computed from merged PR context (pull_request + closed + merged). Running only on push to main caused Publish-Site to be skipped, so deployed Pages could drift from the latest merged build artifact.