### PR TITLE
Test decoupled gallery publish workflow

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@883fa0c674b728a4bb86767ee326041ef05c0bb6
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@e1a2ac54ae8a5f739bba763b7957a77f443c6aba
     secrets:
       APIKey: ${{ secrets.APIKey }}
       TestData: >-

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@migrate-to-zensical
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@883fa0c674b728a4bb86767ee326041ef05c0bb6
     secrets:
       APIKey: ${{ secrets.APIKey }}
       TestData: >-


### PR DESCRIPTION
## Summary
- pin the Process-PSModule reusable workflow to `e1a2ac54ae8a5f739bba763b7957a77f443c6aba`
- consume the final lint-corrected `decouple-gallery-publish-release` implementation deterministically

## Why
This exercises the new split between gallery publishing and GitHub release creation in MariusTestModule before the Process-PSModule change is merged.

## Validation
- pull request run `31309424413` succeeded against the final pin: planning and repository lint passed; module publishing, GitHub release creation, and site publishing remained safely skipped
- earlier manual dispatch run `30034776914` succeeded: module build, source/module tests across Linux/macOS/Windows, docs/site builds, test aggregation, and coverage all passed
- manual dispatch kept `Publish-Module` and `Publish-Site` skipped as required by event policy, avoiding PowerShell Gallery, GitHub release, and Pages side effects

## Source
- PSModule/Process-PSModule branch: `decouple-gallery-publish-release`
- pinned commit: `e1a2ac54ae8a5f739bba763b7957a77f443c6aba`

## Limit
An actual prerelease publish was not triggered because the caller workflow does not expose a WhatIf input; adding a prerelease label would publish to the real gallery and could create a GitHub release.